### PR TITLE
최대힙 / 실버2 / 35분 / X

### DIFF
--- a/week02/BOJ_11279/최대힙_박유진.java
+++ b/week02/BOJ_11279/최대힙_박유진.java
@@ -1,4 +1,36 @@
 package BOJ_11279;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.PriorityQueue;
+
 public class 최대힙_박유진 {
+    public static void main(String[] args) throws IOException {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            int x = Integer.parseInt(br.readLine());
+
+            if(x == 0){
+                if(pq.isEmpty()){
+                    sb.append(x).append("\n");
+                }
+                else{
+                    sb.append(pq.poll()).append("\n");
+                }
+            }
+            else{
+                pq.add(x);
+            }
+        }
+        System.out.println(sb);
+    }
+
 }


### PR DESCRIPTION
### ⭐️ 문제에서 주로 사용한 알고리즘 
- 알고리즘 종류: 우선순위 큐, 힙
- 알고리즘 개념 간단 설명: 
> **우선순위 큐(PriorityQueue)** 
FIFO 형태의 큐에서 우선순위를 적용한 것으로, 기본적으로 선입선출을 하나, 우선순위가 높은 것 부터 출력한다.

> **힙(Heap)**
데이터 삽입 삭제에 모두 O(log n)의 시간 복잡도를 가지는 자료구조로 완전 이진 트리 형태이다. 부모의 값은 항상 자식(들)의 값보다 크거나(최대 힙), 작아야(최소 힙)하는 규칙이 있다. 따라서 루트 노드에는 항상 데이터들 중 가장 큰 값(혹은 가장 작은 값)이 저장되어 있기 때문에, 최댓값(혹은 최솟값)을 O(1) 안에 찾을 수 있다.

### 대략적인 코드 설명
- 자바에서 우선순위 큐가 힙으로 구현된다는 걸 처음 알게 되었습니다.
- 또한 기본은 오름차순 정렬이기 때문에 내림차순의 경우 Collections.reverseOrder()을 넣어줘야한다는 것을 알았습니다!
```java
// PriorityQueue 는 기본적으로 오름차순 정렬이므로 
// Collections.reverseOrder()을 사용하여 내림차순 으로 변경
PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
```
```java
 for (int i = 0; i < n; i++) {
            int x = Integer.parseInt(br.readLine());

            if(x == 0){
               // 0이 입력되었을때 비어있는 경우 0을 출력해야하므로 0 그대로 붙여넣음
                if(pq.isEmpty()){
                    sb.append(x).append("\n");
                }
                else{
                // 비어있지 않다면 가장 큰 값 출력
                    sb.append(pq.poll()).append("\n");
                }
            }
           // 0 이 아닌 다른 자연수가 입력된 경우, 삽입
           // java에서 우선순위 큐는 heap으로 구현되어 삽입, 삭제 이후에도 정렬된다.
            else{
                pq.add(x);
            }
        }
```

### 추가적으로 알게된 사실
<img width="948" alt="image" src="https://github.com/user-attachments/assets/3a375dbc-b8b8-4720-816e-7059912a384b" />

출처: [[JAVA] Queue 자료구조 add와 offer 차이](https://zhfvkq.tistory.com/8)


### 코드 리뷰시 요청사항
- 피드백, 의견 환영합니다!