### PR TITLE
거스름돈 / 실버5 / 20분 / O

### DIFF
--- a/week04/BOJ_14916/거스름돈_민기.java
+++ b/week04/BOJ_14916/거스름돈_민기.java
@@ -1,0 +1,24 @@
+package BOJ_14916;
+
+import java.util.*;
+import java.io.*;
+
+public class 거스름돈_민기 {
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int count =0;
+
+		while (N >= 0) {
+			if (N % 5 == 0) { // 5원으로 나누어 떨어지면 바로 출력
+				count += N / 5;
+				System.out.println(count);
+				return;
+			}
+			N -= 2; // 5원으로 나누어 떨어질 때까지 2원짜리를 사용
+			count++;
+		}
+
+		System.out.println(-1); // 거슬러 줄 수 없는 경우
+	}
+}


### PR DESCRIPTION
## ⭐️ 알고리즘 분류
- 알고리즘 종류: 그리디 알고리즘
- 알고리즘 개념: 거스름돈 문제에서 큰 단위의 동전부터 최대한 사용하여 최소 동전 개수를 구하는 방식 원래는 5원씩 빼면서 최소값을 찾을까 했었는데 생각보다 경우의 수가 많아 지는것 같아 포기하고 2원씩 빼면서 5원으로 나누는 경우로 선택

## 대략적인 코드 설명
1. 입력받은 금액을 5로 나눌 수 있을 때까지 2원씩 빼면서 진행
2. 5로 나누어 떨어질 때 그 몫을 카운트에 더함
3. 음수가 되면 거슬러 줄 수 없는 경우이므로 -1 출력

### 시간 복잡도
- O(N): N은 입력받은 거스름돈 금액

### 코드 리뷰시 요청사항
- 직접 풀었는데도 이해가 잘 되지 않았다. 5원을 빼면서 구현을 하다가 너무 안돼서 2원을 빼는 경우로 대체했는데 이게 왜 됐는지는 잘 모르겠다...