### PR TITLE
민겸수 / 실버1 / 69분 / X

### DIFF
--- a/week04/BOJ_21314/민겸수_박유진.java
+++ b/week04/BOJ_21314/민겸수_박유진.java
@@ -1,4 +1,52 @@
 package BOJ_21314;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public class 민겸수_박유진 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+
+        int idx = 0;
+        StringBuilder minTodigit = new StringBuilder();
+
+        //최대값 구하기
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == 'M') {
+                idx += 1;
+            } else {
+                minTodigit.append(5).append("0".repeat(idx));
+                idx = 0;
+            }
+        }
+        if (idx > 0) {
+            minTodigit.append("1".repeat(idx));
+        }
+        minTodigit.append('\n');
+
+        idx = 0;
+
+        //최소값 구하기
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == 'M') {
+                idx += 1;
+            } else {
+                if (idx > 0){
+                    minTodigit.append(1).append("0".repeat(idx-1)).append(5);
+                    idx = 0;
+                }
+                else{
+                    minTodigit.append(5);
+                }
+            }
+        }
+
+        if ( idx >0) {
+            minTodigit.append(1).append("0".repeat(idx-1));
+        }
+
+        System.out.println(minTodigit);
+    }
 }


### PR DESCRIPTION
> 범위 초과로 통과 실패하여 해설 참고
> (예시) MMMMMMMMMMMKKKKKKKKKKK 

### ⭐️ 문제에서 주로 사용한 알고리즘
- 알고리즘 종류: 그리디

### 대략적인 코드 설명
- 최대값일 경우에는 앞에서부터 K를 만날 때까지의 M의 개수만큼 10^m 해준 후, 5를 곱하는 것이 최적의 값 입니다.
- 최소값일 경우에는 앞에서부터 K를 만날 때까지의 M의 개수 -1 만큼 10^(m-1)해준 후, 5를 곱하지 않고 더하는 것이 최적의 값 입니다.
- 처음에 int로 민겸수 변환을 구현하였으나, int뿐만아니라 long 또한 범위 초과가 되어 반례 참고하여 String으로 바로 붙여넣는 방법을 적용하였습니다.

### 시간 복잡도
- 문자열 하나씩 검사( O(n) ) * 변환 후 문자열 붙이기 반복 ( O(n) ) ~=  O(n^2) 

### 코드 리뷰시 요청사항
- 시간 복잡도 계산이 이게 맞는지 잘 모르겠네요. 혹시 잘못 계산했다면 코멘트 남겨주세요!