### PR TITLE
합구하기 / 실버3 / 29분 / O

### DIFF
--- a/week07/BOJ_11441/합구하기_박유진.java
+++ b/week07/BOJ_11441/합구하기_박유진.java
@@ -1,9 +1,50 @@
 package BOJ_11441;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
 
 public class 합구하기_박유진 {
   public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringBuilder sb = new StringBuilder();
+    StringTokenizer st;
+
+    // n < 100,000
+    // -1000 <Ai < -1000
+    // 구간의 개수 m개
+    // 넷째 줄부터 M개의 줄 각구간 i <= j
+
+    List<Integer> acc = new ArrayList<>();
+
+    int n = Integer.parseInt(br.readLine());
+    st = new StringTokenizer(br.readLine());
+
+    //입력 받으면서 누적합 저장
+    for (int i = 0; i < n; i++) {
+      if (i == 0) {
+        acc.add(Integer.parseInt(st.nextToken()));
+        continue;
+      }
+      acc.add(acc.get(i - 1) + Integer.parseInt(st.nextToken()));
+    }
+
+    int m = Integer.parseInt(br.readLine());
+
+    for (int k = 0; k < m; k++) {
+      st = new StringTokenizer(br.readLine());
+      int i = Integer.parseInt(st.nextToken());
+      int j = Integer.parseInt(st.nextToken());
+      if(i==1){
+        sb.append(acc.get(j-1)).append("\n");
+      }else{
+        sb.append(acc.get(j-1) - acc.get(i - 2)).append("\n");
+      }
+    }
+
+    System.out.println(sb);
   }
 }


### PR DESCRIPTION
### ⭐️ 문제에서 주로 사용한 알고리즘
- 알고리즘 종류: 누적합
- 알고리즘 간단 설명: 구간합을 구할 때, 전체 구간을 탐색하면서 매번 특정 구간의 누적합을 구하는 방법은 시간복잡도가 크기 때문에 불리하다. 따라서 미리 전체의 누적합을 구한 후에, 그 전체 누적합 데이터를 이용하여 구간의 누적합을 구하는 방법이다. 예를들어 1, 2, 3, 4, 5의 누적합을 나타내면 1, 3, 6, 10, 15 이다. 여기서 3~5의 누적합을 구한다고 하자. 다음과 같은 식을 세워 3~5의 누적합인 12를 구할 수 있다.
```
(1+2+3+4+5) - (1+2) = 3+4+5 = 12 
```
### 대략적인 코드 설명
- 셀프 리뷰에 남기겠습니다.

### 시간 복잡도
- O(n)

### 코드 리뷰시 요청사항