### PR TITLE
부분수열의합 / 실버2 / 30분 / O

### DIFF
--- a/week10/BOJ_1182/부분수열의합_김준우.java
+++ b/week10/BOJ_1182/부분수열의합_김준우.java
@@ -1,0 +1,43 @@
+package BOJ_1182;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 부분수열의합_김준우 {
+  static int N, S;
+  static int[] arr;
+  static int count = 0;
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    N = Integer.parseInt(st.nextToken());
+    S = Integer.parseInt(st.nextToken());
+
+    st = new StringTokenizer(br.readLine());
+    arr = new int[N];
+    for (int i = 0; i < N; i++) {
+      arr[i] = Integer.parseInt(st.nextToken());
+    }
+
+    dfs(0, 0);
+    if (S == 0) {
+      count--; // 공집합을 제외하기 위해
+    }
+    System.out.println(count);
+  }
+
+  static void dfs(int depth, int sum) {
+    if (depth == N) {
+      if (sum == S) {
+        count++;
+      }
+      return;
+    }
+    dfs(depth + 1, sum + arr[depth]);
+
+    dfs(depth + 1, sum); //공집합까지 포함하게 된다
+  }
+}


### PR DESCRIPTION
### ⭐️ 문제에서 주로 사용한 알고리즘
- 알고리즘 종류: DFS를 이용한 부분 수열 탐색

### 대략적인 코드 설명
- dfs를 사용하였고 기저 조건을 살펴보면 깊이가 N이 되어야 합니다. 그 이유는 그 전에 재귀가 끝나면 모든 원소들을 탐색할 수 없기 때문입니다.
- 합이 S가 되면 count를 1씩 더하였고 최종 출력을 count를 통해 하였습니다.
- dfs 재귀식에서 sum + arr[depth]와 sum 2가지 식이 존재하는데, 간단히 생각하면 배열에서 어떠한 원소가 있을 때 해당 원소를 선택할지 선택하지 않을지 구분한 것이라고 생각하면 됩니다!

### 시간 복잡도

### 코드 리뷰시 요청사항