### PR TITLE
단지번호붙이기 / 실버1 / 26분 / O

### DIFF
--- a/re02/BOJ_2667/단지번호붙이기_박유진.java
+++ b/re02/BOJ_2667/단지번호붙이기_박유진.java
@@ -1,0 +1,73 @@
+package BOJ_2667;
+
+import java.util.*;
+import java.io.*;
+
+public class 단지번호붙이기_박유진 {
+
+  static int count;
+  static int n;
+  static int total;
+  static int[][] map = new int[26][26];
+  static boolean[][] visited = new boolean[26][26];
+  static int[] dy = {1, 0, -1, 0};
+  static int[] dx = {0, 1, 0, -1};
+
+  static void dfs(int y, int x) {
+    visited[y][x] = true;
+    count++;
+
+    for (int i = 0; i < 4; i++) {
+      int ny = y + dy[i];
+      int nx = x + dx[i];
+
+      if (ny < 0 || nx < 0 || nx > n || ny > n) {
+        continue;
+      }
+      if (visited[ny][nx] || map[ny][nx] != 1) {
+        continue;
+      }
+      dfs(ny, nx);
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    n = Integer.parseInt(br.readLine());
+
+    ArrayList<Integer> result = new ArrayList<>();
+
+    for (int i = 0; i < n; i++) {
+      String lines = br.readLine();
+      for (int j = 0; j < n; j++) {
+        map[i][j] = Integer.parseInt(lines.substring(j, j + 1));
+      }
+    }
+
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < n; j++) {
+        if (!visited[i][j] && map[i][j] == 1) {
+          count = 0;
+          total++;
+          dfs(i, j);
+          result.add(count);
+        }
+      }
+    }
+
+    Collections.sort(result);
+
+    bw.write(total + "\n");
+
+    for(int i = 0; i < result.size(); i++) {
+      bw.write(result.get(i) + "\n");
+    }
+
+    bw.flush();
+    bw.close();
+
+  }
+}
+


### PR DESCRIPTION
### ⭐️ 문제에서 주로 사용한 알고리즘
- 알고리즘 종류: DFS
- 알고리즘 개념 간단 설명: 깊이우선탐색
재귀적으로 이어져있는 노드들을 리프까지 찾아나가는 알고리즘
  
### 📝 대략적인 코드 설명
```java
for (int i = 0; i < n; i++) {
      String lines = br.readLine();
      for (int j = 0; j < n; j++) { 
        // 구분자가 없는 문자열로 주어지므로 하나씩 담기 위해 substring으로 한글자씩 자르는 과정
        map[i][j] = Integer.parseInt(lines.substring(j, j + 1));
      }
    }
```

```java
for (int i = 0; i < n; i++) {
      for (int j = 0; j < n; j++) {
        // 방문하지 않았고,  집이 있는 곳이라면
        if (!visited[i][j] && map[i][j] == 1) {
          count = 0; // 세대 수 초기화
          total++;  //단지 수 +1
          dfs(i, j); // 연결되어있는 세대 방문 처리 및 세대 수 계산
          result.add(count); // dfs로 탐색 완료 후 세대 수 결과 리스트에 추가
        }
      }
    }
```

```java
  static void dfs(int y, int x) {
    visited[y][x] = true;     // 지금 도착한 곳 방문 처리
    count++; // 세대 수 +1

    for (int i = 0; i < 4; i++) {
      int ny = y + dy[i];
      int nx = x + dx[i];

      if (ny < 0 || nx < 0 || nx > n || ny > n) { // 다음에 방문하려는 곳이 범위에서 벗어났다면 다음 방향 탐색
        continue;
      }
      if (visited[ny][nx] || map[ny][nx] != 1) { // 다음에 방문하려는 곳이 이미 방문한 곳이거나 집이 있는 곳(1)이 아니라면 다음 방향 탐색
        continue;
      }
      dfs(ny, nx); // 위 모든 조건을 통과한다면, 집이 있는 곳이면서 아직 방문하지 않은 곳이므로 이어서 탐색
    }
  }
```

### ⏳ 시간 복잡도
- O(N^2)


### 회고
- Java 로 String -> char로 바꿀 때 항상 멈칫 하는 것 같다. 다른 언어는 인덱스로 접근이 가능하지만 자바에서는 메서드로 가져올 수 있어서 익숙하지 않은 것 같다. 여러 문제들을 풀어보고 여러 메소드들을 사용해보면서 익숙해져야 할 것 같다.
```java
        map[i][j] = Integer.parseInt(lines.substring(j, j + 1));
```
-  이 문제에서는 0과 1만 주어졌기에 준우님이 사용하신 방법인 '입력받은 문자' - '0'한 값을 저장해도 좋을 것 같다. 아니면 Character.getNumericValue(c) 을 사용한다거나... 또한 toCharArray(),getChars() 를 활용하여 숫자가 아닌 문자로 저장하는 방법도 좋을 것 같다.
- 잘한 점: 
    - 일단 메서드가 생각안나더라도 최대한 기억나는걸 활용해서 구현했다! 
- 아쉬운 점:
   - 메서드가 기억 안났던 것... 
   - 실행을 돌려보고 난 뒤에 조건문이 빠졌다는 걸 알았다는 것
   -> 실행 전에 한 번만 더 체크할 수 있도록 하자.

### 🪄 코드 리뷰시 요청사항